### PR TITLE
Add EFS provisioner container in 3.7

### DIFF
--- a/images/efs-provisioner/Dockerfile
+++ b/images/efs-provisioner/Dockerfile
@@ -26,8 +26,8 @@ LABEL \
         url="https://github.com/kubernetes-incubator/external-storage/blob/master/aws/efs/README.md" \
         io.k8s.display-name="EFS Provisioner" \
         summary="AWS EFS dynamic PV provisioner" \
-        version="v3.10.34" \
+        version="v3.7.62" \
         architecture="x86_64" \
         io.openshift.tags="aws,efs,dynamic,provisioner" \
-        name="openshift3/efs-provisioner"
+        name="openshift3/origin-efs-provisioner"
 


### PR DESCRIPTION
@wongma7, @tsmetana: could you take a look, please?

This is based on the instructions here [1]. This Dockerfile is based on the one that @wongma7 pushed to the master branch yesterday (which in turn was taken from dist-git).

If I understand correctly, I don't need to create a specfile as the package `openshift-external-storage-efs-provisioner` should be already available in the image.

[1] https://jira.coreos.com/browse/ART-85