### PR TITLE
Add EFS provisioner dockerfile to 3.10

### DIFF
--- a/images/efs-provisioner/Dockerfile
+++ b/images/efs-provisioner/Dockerfile
@@ -1,0 +1,33 @@
+#oit## This file is managed by the OpenShift Image Tool: https://github.com/openshift/enterprise-images
+#oit## by the OpenShift Continuous Delivery team (#aos-cd-team on IRC).
+#oit## 
+#oit## Any yum repos listed in this file will effectively be ignored during CD builds.
+#oit## Yum repos must be enabled in the oit configuration files.
+#oit## Some aspects of this file may be managed programmatically. For example, the image name, labels (version,
+#oit## release, and other), and the base FROM. Changes made directly in distgit may be lost during the next
+#oit## reconciliation.
+#oit## 
+FROM rhel7:7-released
+
+RUN yum-config-manager --enable rhel-7-server-ose-3.7-rpms
+RUN yum install -y openshift-external-storage-efs-provisioner
+RUN yum clean all
+
+USER root
+
+ENTRYPOINT ["/usr/bin/efs-provisioner"]
+
+LABEL \
+        io.k8s.description="AWS EFS dynamic PV provisioner." \
+        com.redhat.component="efs-provisioner-container" \
+        vendor="Red Hat" \
+        description="AWS EFS dynamic PV provisioner" \
+        License="GPLv2+" \
+        url="https://github.com/kubernetes-incubator/external-storage/blob/master/aws/efs/README.md" \
+        io.k8s.display-name="EFS Provisioner" \
+        summary="AWS EFS dynamic PV provisioner" \
+        version="v3.10" \
+        architecture="x86_64" \
+        io.openshift.tags="aws,efs,dynamic,provisioner" \
+        name="openshift3/origin-efs-provisioner"
+


### PR DESCRIPTION
The EFS provisioner Dockerfile was missing in the 3.10 branch: adding the one from 3.9.

Should help resolving https://bugzilla.redhat.com/show_bug.cgi?id=1629579

@wongma7, @jsafrane, @bertinatto PTAL