### PR TITLE
3.11: Add spec file, include CephFS patch in-tree

### DIFF
--- a/ceph/cephfs/cephfs-provisioner.go
+++ b/ceph/cephfs/cephfs-provisioner.go
@@ -140,6 +140,9 @@ func (p *cephFSProvisioner) Provision(options controller.VolumeOptions) (*v1.Per
 	if deterministicNames {
 		cmd.Env = append(cmd.Env, "CEPH_VOLUME_GROUP="+options.PVC.Namespace)
 	}
+	if *disableCephNamespace {
+		cmd.Env = append(cmd.Env, "CEPH_FEATURE_PNAMESPACE_DISABLED=true")
+	}
 
 	output, cmdErr := cmd.CombinedOutput()
 	if cmdErr != nil {
@@ -243,6 +246,9 @@ func (p *cephFSProvisioner) Delete(volume *v1.PersistentVolume) error {
 		"CEPH_AUTH_ID=" + adminID,
 		"CEPH_AUTH_KEY=" + adminSecret,
 		"CEPH_VOLUME_ROOT=" + pvcRoot}
+	if *disableCephNamespace {
+		cmd.Env = append(cmd.Env, "CEPH_FEATURE_PNAMESPACE_DISABLED=true")
+	}
 
 	output, cmdErr := cmd.CombinedOutput()
 	if cmdErr != nil {
@@ -333,10 +339,11 @@ func (p *cephFSProvisioner) parsePVSecret(namespace, secretName string) (string,
 }
 
 var (
-	master          = flag.String("master", "", "Master URL")
-	kubeconfig      = flag.String("kubeconfig", "", "Absolute path to the kubeconfig")
-	id              = flag.String("id", "", "Unique provisioner identity")
-	secretNamespace = flag.String("secret-namespace", "", "Namespace secrets will be created in (default: '', created in each PVC's namespace)")
+	master               = flag.String("master", "", "Master URL")
+	kubeconfig           = flag.String("kubeconfig", "", "Absolute path to the kubeconfig")
+	id                   = flag.String("id", "", "Unique provisioner identity")
+	secretNamespace      = flag.String("secret-namespace", "", "Namespace secrets will be created in (default: '', created in each PVC's namespace)")
+	disableCephNamespace = flag.Bool("disable-ceph-namespace", false, "Disable Ceph namespace support")
 )
 
 func main() {

--- a/ceph/cephfs/cephfs_provisioner/cephfs_provisioner.py
+++ b/ceph/cephfs/cephfs_provisioner/cephfs_provisioner.py
@@ -16,9 +16,11 @@
 
 import os
 import rados
+import cephfs
 import getopt
 import sys
 import json
+import logging
 
 """
 CEPH_CLUSTER_NAME=test CEPH_MON=172.24.0.4 CEPH_AUTH_ID=admin CEPH_AUTH_KEY=AQCMpH9YM4Q1BhAAXGNQyyOne8ZsXqWGon/dIQ== cephfs_provisioner.py -n foo -u bar
@@ -33,6 +35,8 @@ except ImportError as e:
 VOlUME_GROUP="kubernetes"
 CONF_PATH="/etc/ceph/"
 
+log = logging.getLogger(__name__)
+
 class CephFSNativeDriver(object):
     """Driver for the Ceph Filesystem.
 
@@ -41,6 +45,11 @@ class CephFSNativeDriver(object):
     """
 
     def __init__(self, *args, **kwargs):
+        try:
+            os.environ["CEPH_FEATURE_PNAMESPACE_DISABLED"]
+            self.ceph_feature_namespace_disabled = True
+        except KeyError:
+            self.ceph_feature_namespace_disabled = False
         self._volume_client = None
         # Default volume_prefix to None; the CephFSVolumeClient constructor uses a ternary operator on the input argument to default it to /volumes
         self.volume_prefix = os.environ.get('CEPH_VOLUME_ROOT', None)
@@ -116,15 +125,23 @@ class CephFSNativeDriver(object):
         # First I need to work out what the data pool is for this share:
         # read the layout
         pool_name = self._volume_client._get_ancestor_xattr(path, "ceph.dir.layout.pool")
-        namespace = self._volume_client.fs.getxattr(path, "ceph.dir.layout.pool_namespace")
+        try:
+            namespace = self._volume_client.fs.getxattr(path, "ceph.dir.layout.pool_namespace")
+        except cephfs.NoData:
+            # ceph.dir.layout.pool_namespace is optional
+            namespace = ""
 
         # Now construct auth capabilities that give the guest just enough
         # permissions to access the share
         client_entity = "client.{0}".format(auth_id)
         want_access_level = 'r' if readonly else 'rw'
         want_mds_cap = 'allow r,allow {0} path={1}'.format(want_access_level, path)
-        want_osd_cap = 'allow {0} pool={1} namespace={2}'.format(
-            want_access_level, pool_name, namespace)
+        if namespace != "":
+            want_osd_cap = 'allow {0} pool={1} namespace={2}'.format(
+                want_access_level, pool_name, namespace)
+        else:
+            want_osd_cap = 'allow {0} pool={1}'.format(
+                want_access_level, pool_name)
 
         try:
             existing = self._volume_client._rados_command(
@@ -152,8 +169,12 @@ class CephFSNativeDriver(object):
             # auth caps.
             unwanted_access_level = 'r' if want_access_level is 'rw' else 'rw'
             unwanted_mds_cap = 'allow {0} path={1}'.format(unwanted_access_level, path)
-            unwanted_osd_cap = 'allow {0} pool={1} namespace={2}'.format(
-                unwanted_access_level, pool_name, namespace)
+            if namespace != "":
+                unwanted_osd_cap = 'allow {0} pool={1} namespace={2}'.format(
+                    unwanted_access_level, pool_name, namespace)
+            else:
+                unwanted_osd_cap = 'allow {0} pool={1}'.format(
+                    unwanted_access_level, pool_name)
 
             def cap_update(orig, want, unwanted):
                 # Updates the existing auth caps such that there is a single
@@ -201,13 +222,57 @@ class CephFSNativeDriver(object):
         assert caps[0]['entity'] == client_entity
         return caps[0]
 
+    def _create_volume(self, volume_path, size=None, namespace_enforced=True):
+        """
+        Linux kernel cephfs only support Rados Pool Namespace after 4.8:
+        https://github.com/torvalds/linux/commit/779fe0fb8e1883d5c479ac6bd85fbd237deed1f7.
+        This methid is modified from
+        https://github.com/ceph/ceph/blob/v13.0.0/src/pybind/ceph_volume_client.py#L603
+        and make namespace enforcement optional.
+        Set up metadata, pools and auth for a volume.
+        This function is idempotent.  It is safe to call this again
+        for an already-created volume, even if it is in use.
+        :param volume_path: VolumePath instance
+        :param size: In bytes, or None for no size limit
+        :param namespace_enforced: If true, enforce security isolation, use seperate namespace for this volume.
+        :return:
+        """
+        path = self.volume_client._get_path(volume_path)
+        log.info("create_volume: {0}".format(path))
+
+        self.volume_client._mkdir_p(path)
+
+        if size is not None:
+            self.volume_client.fs.setxattr(path, 'ceph.quota.max_bytes', size.__str__(), 0)
+
+        # enforce security isolation, use seperate namespace for this volume
+        if namespace_enforced:
+            namespace = "{0}{1}".format(self.volume_client.pool_ns_prefix, volume_path.volume_id)
+            log.info("create_volume: {0}, using rados namespace {1} to isolate data.".format(volume_path, namespace))
+            self.volume_client.fs.setxattr(path, 'ceph.dir.layout.pool_namespace', namespace, 0)
+        else:
+            # If `ceph.dir.layout.pool_namespace` is not configured, `ceph.dir.layout.pool` is inherited from ancestor which may change.
+            # Make sure `ceph.dir.layout.pool` is configured on volume path, so we will not have any permission issues in future.
+            pool_name = self.volume_client._get_ancestor_xattr(path, "ceph.dir.layout.pool")
+            self.volume_client.fs.setxattr(path, 'ceph.dir.layout.pool', pool_name, 0)
+
+        # Create a volume meta file, if it does not already exist, to store
+        # data about auth ids having access to the volume
+        fd = self.volume_client.fs.open(self.volume_client._volume_metadata_path(volume_path),
+                          os.O_CREAT, 0o755)
+        self.volume_client.fs.close(fd)
+
+        return {
+            'mount_path': path
+        }
+
     def create_share(self, path, user_id, size=None):
         """Create a CephFS volume.
         """
         volume_path = ceph_volume_client.VolumePath(self.volume_group, path)
 
         # Create the CephFS volume
-        volume = self.volume_client.create_volume(volume_path, size=size)
+        volume = self._create_volume(volume_path, size=size, namespace_enforced=not self.ceph_feature_namespace_disabled)
 
         # To mount this you need to know the mon IPs and the path to the volume
         mon_addrs = self.volume_client.get_mon_addrs()
@@ -240,16 +305,27 @@ class CephFSNativeDriver(object):
         client_entity = "client.{0}".format(auth_id)
         path = self.volume_client._get_path(volume_path)
         pool_name = self.volume_client._get_ancestor_xattr(path, "ceph.dir.layout.pool")
-        namespace = self.volume_client.fs.getxattr(path, "ceph.dir.layout.pool_namespace")
+        try:
+            namespace = self.volume_client.fs.getxattr(path, "ceph.dir.layout.pool_namespace")
+        except cephfs.NoData:
+            # ceph.dir.layout.pool_namespace is optional
+            namespace = ""
+
 
         # The auth_id might have read-only or read-write mount access for the
         # volume path.
         access_levels = ('r', 'rw')
         want_mds_caps = {'allow {0} path={1}'.format(access_level, path)
                          for access_level in access_levels}
-        want_osd_caps = {'allow {0} pool={1} namespace={2}'.format(
-                         access_level, pool_name, namespace)
-                         for access_level in access_levels}
+        if namespace != "":
+            want_osd_caps = {'allow {0} pool={1} namespace={2}'.format(
+                             access_level, pool_name, namespace)
+                             for access_level in access_levels}
+        else:
+            want_osd_caps = {'allow {0} pool={1}'.format(
+                             access_level, pool_name)
+                             for access_level in access_levels}
+
 
         try:
             existing = self.volume_client._rados_command(

--- a/openshift-external-storage.spec
+++ b/openshift-external-storage.spec
@@ -1,0 +1,192 @@
+# Build project from bundled dependencies
+%global with_bundled 1
+# Build with debug info rpm
+%global with_debug 1
+
+%if 0%{?with_debug}
+%global _dwz_low_mem_die_limit 0
+%else
+%global debug_package   %{nil}
+%endif
+
+%if ! 0%{?gobuild:1}
+%define gobuild(o:) go build -ldflags "${LDFLAGS:-} -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n')" -a -v -x %{?**};
+%endif
+
+%global provider        github
+%global provider_tld    com
+%global project         kubernetes-incubator
+%global repo            external-storage
+# https://github.com/kubernetes-incubator/external-storage
+%global provider_prefix %{provider}.%{provider_tld}/%{project}/%{repo}
+%global import_path     %{provider_prefix}
+%global commit          1ffdb9d63c8415e752716f67d5bd3ac0f823298f
+%global shortcommit     %(c=%{commit}; echo ${c:0:7})
+
+Name:           openshift-external-storage
+Version:        0.0.3
+Release:        2.git%{shortcommit}%{?dist}
+Summary:        External storage plugins, provisioners, and helper libraries for OpenShift
+License:        ASL 2.0
+URL:            https://%{provider_prefix}
+Source0:        https://%{provider_prefix}/archive/%{commit}/%{repo}-%{shortcommit}.tar.gz
+
+# e.g. el6 has ppc64 arch without gcc-go, so EA tag is required
+ExclusiveArch:  %{?go_arches:%{go_arches}}%{!?go_arches:%{ix86} x86_64 aarch64 %{arm} ppc64le s390x}
+# If go_compiler is not set to 1, there is no virtual provide. Use golang instead.
+BuildRequires:  %{?go_compiler:compiler(go-compiler)}%{!?go_compiler:golang}
+
+%description
+%{summary}
+
+%package efs-provisioner
+Summary: AWS EFS dynamic PV provisioner
+
+%description efs-provisioner
+AWS EFS dynamic PV provisioner.
+
+%package local-provisioner
+Summary: Provisioner for local PersistentVolumes
+Requires: e2fsprogs
+
+%description local-provisioner
+Provisioner for local PersistentVolumes.
+
+%package snapshot-controller
+Summary: External controller for volume snapshots
+
+%description snapshot-controller
+External controller for volume snapshots.
+
+%package snapshot-provisioner
+Summary: Provisioner for restoring snapshots to PersistentVolumes
+
+%description snapshot-provisioner
+Provisioner for restoring snapshots to PersistentVolumes
+
+%package cephfs-provisioner
+Summary: Provisioner for CephFS volumes
+Requires: ceph-common python-cephfs
+
+%description cephfs-provisioner
+Provisioner for CephFS volumes.
+
+%package manila-provisioner
+Summary: Provisioner for OpenStack Manila
+
+%description manila-provisioner
+Provisions volumes using OpenStack Manila API.
+
+%prep
+%setup -q -n %{repo}-%{commit}
+
+%build
+mkdir -p src/%{provider}.%{provider_tld}/%{project}
+ln -s ../../../ src/%{import_path}
+export GOPATH=$(pwd):$(pwd)/repo-infra/vendor:%{gopath}
+
+%gobuild -o bin/aws/efs/cmd/efs-provisioner %{import_path}/aws/efs/cmd/efs-provisioner
+%gobuild -o bin/local-volume/provisioner/local-provisioner %{import_path}/local-volume/provisioner/cmd
+%gobuild -o bin/local-volume/provisioner/snapshot-controller %{import_path}/snapshot/cmd/snapshot-controller
+%gobuild -o bin/local-volume/provisioner/snapshot-provisioner %{import_path}/snapshot/cmd/snapshot-pv-provisioner
+%gobuild -o bin/cephfs/provisioner/cephfs-provisioner %{import_path}/ceph/cephfs
+cp src/%{import_path}/ceph/cephfs/cephfs_provisioner/cephfs_provisioner.py bin/cephfs/provisioner/
+%gobuild -o bin/openstack-manila/provisioner/manila-provisioner %{import_path}/openstack-sharedfilesystems/cmd/manila-provisioner
+
+%install
+install -d -p %{buildroot}%{_bindir}
+install -d -p %{buildroot}%{_prefix}/local/bin
+install -p -m 0755 bin/aws/efs/cmd/efs-provisioner %{buildroot}%{_bindir}
+install -p -m 0755 bin/local-volume/provisioner/local-provisioner %{buildroot}%{_bindir}
+install -p -m 0755 bin/local-volume/provisioner/snapshot-controller %{buildroot}%{_bindir}
+install -p -m 0755 bin/local-volume/provisioner/snapshot-provisioner %{buildroot}%{_bindir}
+install -p -m 0755 bin/cephfs/provisioner/cephfs-provisioner %{buildroot}%{_bindir}
+# FIXME: The path to the helper script is hard-coded in the binary
+install -p -m 0755 bin/cephfs/provisioner/cephfs_provisioner.py %{buildroot}%{_prefix}/local/bin/
+install -p -m 0755 bin/openstack-manila/provisioner/manila-provisioner %{buildroot}%{_bindir}
+mkdir -p %{buildroot}%{_libexecdir}/%{name}-local-provisioner/scripts
+install -p -m 0755 \
+	src/%{import_path}/local-volume/provisioner/deployment/docker/scripts/* \
+	%{buildroot}%{_libexecdir}/%{name}-local-provisioner/scripts
+
+%files efs-provisioner
+%{_bindir}/efs-provisioner
+%license LICENSE
+%doc CONTRIBUTING.md RELEASE.md README.md
+
+%files local-provisioner
+%{_bindir}/local-provisioner
+%{_libexecdir}/%{name}-local-provisioner
+%license LICENSE
+%doc CONTRIBUTING.md RELEASE.md README.md
+
+%files snapshot-controller
+%{_bindir}/snapshot-controller
+%license LICENSE
+%doc CONTRIBUTING.md RELEASE.md README.md
+
+%files snapshot-provisioner
+%{_bindir}/snapshot-provisioner
+%license LICENSE
+%doc CONTRIBUTING.md RELEASE.md README.md
+
+%files cephfs-provisioner
+%{_bindir}/cephfs-provisioner
+%{_prefix}/local/bin/cephfs_provisioner.py
+%license LICENSE
+%doc CONTRIBUTING.md RELEASE.md README.md
+
+%files manila-provisioner
+%{_bindir}/manila-provisioner
+%license LICENSE
+%doc CONTRIBUTING.md RELEASE.md README.md
+
+%changelog
+* Tue Oct 09 2018 Tomas Smetana <tsmetana@redhat.com> - 0.0.3-2
+- Move CephFS patch to forked repo
+
+* Tue Jul 31 2018 Matthew Wong <mawong@redhat.com> - 0.0.3-1.git1ffdb9d
+- Rebase to latest upstream version
+
+* Tue May 29 2018 Tomas Smetana <tsmetana@redhat.com> - 0.0.2-3.gitd3c94f0
+- Install local-provisioners helper scripts
+
+* Fri Apr 13 2018 Tomas Smetana <tsmetana@redhat.com> - 0.0.2-2.gitd3c94f0
+- Workaround to allow ceph_volume_client to create 'volumes' without namespace isolation
+- Resolves: rhbz#1566194
+
+* Tue Apr 03 2018 Tomas Smetana <tsmetana@redhat.com> - 0.0.2-1.gitd3c94f0
+- Rebase to latest upstream version; drop upstreamed patches
+- Add CephFS and Manila provisioner
+- Resolves: rhbz#1547884, rhbz#1548996, rhbz#1490722
+
+* Thu Feb 22 2018 jsafrane <jsafrane@redhat.com> - 0.0.1-9.git78d6339
+- Fix local provisioner to discover only mount points and not empty directories
+- Resolves: rhbz#1490722
+
+* Fri Feb 16 2018 jsafrane <jsafrane@redhat.com> - 0.0.1-8.git78d6339
+- Rebuilt for 3.9
+
+* Mon Feb 12 2018 jsafrane <jsafrane@redhat.com> - 0.0.1-7.git78d6339
+- Fix error message when a plain file is discovered
+- Resolves: rhbz#1542867
+
+* Thu Nov 16 2017 Yaakov Selkowitz <yselkowi@redhat.com> - 0.0.1-6.git78d6339
+- Rebuilt for multi-arch enablement
+
+* Mon Nov 13 2017 Tomas Smetana <tsmetana@redhat.com> - 0.0.1-5.git78d6339
+- Rename the snapshot provisioner binary according to upstream one
+
+* Thu Nov 09 2017 Tomas Smetana <tsmetana@redhat.com> - 0.0.1-4.git78d6339
+- Rename snapshot API to be consistent with the new upstream APIs
+
+* Thu Oct 19 2017 Tomas Smetana <tsmetana@redhat.com> - 0.0.1-3.git78d6339
+- Backport GCE PD code for snapshots
+- Resolves: rhbz#1503015, rhbz#1502945
+
+* Tue Sep 26 2017 jsafrane <jsafrane@redhat.com> - 0.0.1-2.git78d6339
+- Rename local-storage-provisioner to local-provisioner
+
+* Wed Sep 20 2017 jsafrane <jsafrane@redhat.com> - 0.0.1-1.git78d6339
+- First release
+


### PR DESCRIPTION
This is a spec file addition to the 3.11 branch. The second patch includes the fix for CephFS that is being part of the 3.10 tree as a patch file.

@wongma7, @rootfs, @jsafrane, @childsb, @gnufied, @bertinatto, PTAL, comments welcome